### PR TITLE
cosine類似度の計算からノルムの除算を除去

### DIFF
--- a/Search.py
+++ b/Search.py
@@ -15,16 +15,9 @@ import libs.loadOpenAI as myopenAI
 def cosine_similarity_numba(u: np.ndarray, v: np.ndarray):
     assert u.shape[0] == v.shape[0]
     uv = 0
-    uu = 0
-    vv = 0
     for i in range(u.shape[0]):
         uv += u[i] * v[i]
-        uu += u[i] * u[i]
-        vv += v[i] * v[i]
-    cos_theta = 1
-    if uu != 0 and vv != 0:
-        cos_theta = uv / np.sqrt(uu * vv)
-    return cos_theta
+    return uv
 
 
 Search = func.Blueprint()


### PR DESCRIPTION
高速化のためcosine類似度の計算からノルム計算およびノルムによる除算を除去。
ただし、AzureOpenAIによるembeddingベクトルが正規化されていることを前提としている。
OpenAIの提供するモデル（e.g. text-embedding-ada-002）は[正規化されていることが保証されている](https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use)。
OpenAI以外の正規化が保証されていないモデルを利用する場合は、csvファイルへの埋め込みのタイミングでembeddingベクトルの正規化を実装する必要がある。